### PR TITLE
Fix bottle_of_failing recipe unlock requirement

### DIFF
--- a/kubejs/server_scripts/mods/spectrum.js
+++ b/kubejs/server_scripts/mods/spectrum.js
@@ -218,7 +218,7 @@ ServerEvents.recipes(e => {
             item: sp('bottle_of_failing'),
             count: 1
         },
-        required_advancement: sp('progression/unlock_bottle_of_failing')
+        required_advancement: sp('unlocks/items/bottle_of_failing')
     });
 
     // -- MAGIC DIAMOND -- //


### PR DESCRIPTION
`progression/unlock_bottle_of_failing`
needs to be changed to 
`unlocks/items/bottle_of_failing`